### PR TITLE
Burnin plugin fix

### DIFF
--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -184,7 +184,9 @@ class ExtractBurnin(openpype.api.Extractor):
                 for key in self.positions:
                     value = burnin_def.get(key)
                     if value:
-                        burnin_values[key] = value
+                        burnin_values[key] = value.replace(
+                            "{task}", "{task[name]}"
+                        )
 
                 # Remove "delete" tag from new representation
                 if "delete" in new_repre["tags"]:


### PR DESCRIPTION
Forgot about burnins plugin which is using `anatomyData` to fill burnin templates.

## Changes
- replace `{task}` in burnin templates with `{task[name]}`