### PR TITLE
Parent key modifications

### DIFF
--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -479,16 +479,17 @@ def get_workdir_data(project_doc, asset_doc, task_name, host_name):
     Returns:
         dict: Data prepared for filling workdir template.
     """
-    hierarchy = "/".join(asset_doc["data"]["parents"])
-
     task_type = asset_doc['data']['tasks'].get(task_name, {}).get('type')
 
     project_task_types = project_doc["config"]["tasks"]
     task_code = project_task_types.get(task_type, {}).get("short_name")
 
-    parent = project_doc["name"]
-    if len(asset_doc["data"]["parents"]) != 0:
-        parent = asset_doc["data"]["parents"][-1]
+    asset_parents = asset_doc["data"]["parents"]
+    hierarchy = "/".join(asset_parents)
+
+    parent_name = project_doc["name"]
+    if asset_parents:
+        parent_name = asset_parents[-1]
 
     data = {
         "project": {
@@ -501,7 +502,7 @@ def get_workdir_data(project_doc, asset_doc, task_name, host_name):
             "short": task_code,
         },
         "asset": asset_doc["name"],
-        "parent": parent,
+        "parent": parent_name,
         "app": host_name,
         "user": getpass.getuser(),
         "hierarchy": hierarchy,

--- a/openpype/plugins/publish/collect_anatomy_context_data.py
+++ b/openpype/plugins/publish/collect_anatomy_context_data.py
@@ -49,20 +49,18 @@ class CollectAnatomyContextData(pyblish.api.ContextPlugin):
         project_entity = context.data["projectEntity"]
         asset_entity = context.data["assetEntity"]
 
-        hierarchy_items = asset_entity["data"]["parents"]
-        hierarchy = ""
-        if hierarchy_items:
-            hierarchy = os.path.join(*hierarchy_items)
-
         asset_tasks = asset_entity["data"]["tasks"]
         task_type = asset_tasks.get(task_name, {}).get("type")
 
         project_task_types = project_entity["config"]["tasks"]
         task_code = project_task_types.get(task_type, {}).get("short_name")
 
-        parent = project_entity["name"]
-        if len(asset_entity["data"]["parents"]) != 0:
-            parent = asset_entity["data"]["parents"][-1]
+        asset_parents = asset_entity["data"]["parents"]
+        hierarchy = "/".join(asset_parents)
+
+        parent_name = project_entity["name"]
+        if asset_parents:
+            parent_name = asset_parents[-1]
 
         context_data = {
             "project": {
@@ -70,7 +68,7 @@ class CollectAnatomyContextData(pyblish.api.ContextPlugin):
                 "code": project_entity["data"].get("code")
             },
             "asset": asset_entity["name"],
-            "parent": parent,
+            "parent": parent_name,
             "hierarchy": hierarchy.replace("\\", "/"),
             "task": {
                 "name": task_name,

--- a/openpype/plugins/publish/collect_anatomy_context_data.py
+++ b/openpype/plugins/publish/collect_anatomy_context_data.py
@@ -69,7 +69,7 @@ class CollectAnatomyContextData(pyblish.api.ContextPlugin):
             },
             "asset": asset_entity["name"],
             "parent": parent_name,
-            "hierarchy": hierarchy.replace("\\", "/"),
+            "hierarchy": hierarchy,
             "task": {
                 "name": task_name,
                 "type": task_type,

--- a/openpype/plugins/publish/collect_anatomy_instance_data.py
+++ b/openpype/plugins/publish/collect_anatomy_instance_data.py
@@ -242,7 +242,11 @@ class CollectAnatomyInstanceData(pyblish.api.ContextPlugin):
             asset_doc = instance.data.get("assetEntity")
             if asset_doc and asset_doc["_id"] != context_asset_doc["_id"]:
                 parents = asset_doc["data"].get("parents") or list()
+                parent_name = project_doc["name"]
+                if parents:
+                    parent_name = parents[-1]
                 anatomy_updates["hierarchy"] = "/".join(parents)
+                anatomy_updates["parent"] = parent_name
 
             # Task
             task_name = instance.data.get("task")

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -85,9 +85,10 @@ class NameWindow(QtWidgets.QDialog):
         project_task_types = project_doc["config"]["tasks"]
         task_short = project_task_types.get(task_type, {}).get("short_name")
 
-        parent = project_doc["name"]
-        if len(asset_doc["data"]["parents"]) != 0:
-            parent = asset_doc["data"]["parents"][-1]
+        asset_parents = asset_doc["data"]["parents"]
+        parent_name = project_doc["name"]
+        if asset_parents:
+            parent_name = asset_parents[-1]
 
         self.data = {
             "project": {
@@ -100,7 +101,7 @@ class NameWindow(QtWidgets.QDialog):
                 "type": task_type,
                 "short": task_short,
             },
-            "parent": parent,
+            "parent": parent_name,
             "version": 1,
             "user": getpass.getuser(),
             "comment": "",

--- a/website/docs/admin_settings_project_anatomy.md
+++ b/website/docs/admin_settings_project_anatomy.md
@@ -57,14 +57,11 @@ We have a few required anatomy templates for OpenPype to work properly, however 
 | `project[code]` | Project's code |
 | `hierarchy` | All hierarchical parents as subfolders |
 | `asset` | Name of asset or shot |
-<<<<<<< HEAD
 | `task[name]` | Name of task |
 | `task[type]` | Type of task |
 | `task[short]` | Shortname of task |
-=======
 | `parent` | Name of parent folder |
 | `task` | Name of task |
->>>>>>> add7db0c0... add parent asset to doc
 | `version` | Version number |
 | `subset` | Subset name |
 | `family` | Main family name |

--- a/website/docs/admin_settings_project_anatomy.md
+++ b/website/docs/admin_settings_project_anatomy.md
@@ -60,7 +60,7 @@ We have a few required anatomy templates for OpenPype to work properly, however 
 | `task[name]` | Name of task |
 | `task[type]` | Type of task |
 | `task[short]` | Shortname of task |
-| `parent` | Name of parent folder |
+| `parent` | Name of hierarchical parent |
 | `task` | Name of task |
 | `version` | Version number |
 | `subset` | Subset name |


### PR DESCRIPTION
## Description
Few changes related to `"parent"` key in templates.

## Changes
- renamed variable from `parent` to `parent_name` just to be more specific what the variable holds
- reuse variable used for hierarchy for parent
- added update of `"parent"` key in `CollectAnatomyInstanceData`
- removed merge conflict marks from docstrings
- modified description of `parent` key in docstrings as it is name of asset's parent