### PR TITLE
Added shotgun-api3 source files to poetry lock

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2818,6 +2818,7 @@ semver = [
     {file = "semver-2.13.0-py2.py3-none-any.whl", hash = "sha256:ced8b23dceb22134307c1b8abfa523da14198793d9787ac838e70e29e77458d4"},
     {file = "semver-2.13.0.tar.gz", hash = "sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f"},
 ]
+shotgun-api3 = []
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},


### PR DESCRIPTION
## Brief description
There are missing source files for `shotgun-api3` in poetry lock which cause crashes.

### Error
```
Installing dependencies from lock file

  NonExistentKey

  'Key "shotgun-api3" does not exist.'

  at .poetry\venv\lib\site-packages\tomlkit\container.py:529 in __getitem__
      525│             key = SingleKey(key)
      526│
      527│         idx = self._map.get(key, None)
      528│         if idx is None:
    → 529│             raise NonExistentKey(key)
      530│
      531│         if isinstance(idx, tuple):
      532│             # The item we are getting is an out of order table
      533│             # so we need a proxy to retrieve the proper objects
!!! Poetry command failed
```